### PR TITLE
Fix anomaly index

### DIFF
--- a/orion/pipelines/lstm_dynamic_threshold.json
+++ b/orion/pipelines/lstm_dynamic_threshold.json
@@ -27,6 +27,11 @@
             "epochs": 35
         }
     },
+    "input_names": {
+        "mlprimitives.custom.timeseries_anomalies.find_anomalies#1": {
+            "index": "target_index"
+        }
+    },
     "output_names": {
         "keras.Sequential.LSTMTimeSeriesRegressor#1": {
             "y": "y_hat"


### PR DESCRIPTION
Index of y and y_hat is stored in target_index, therefore we need target_index instead of index in our find_anomalies function.