### PR TITLE
Update dependency 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ development_requires = [
     'pydata-sphinx-theme',
     'autodocsumm>=0.1.10,<1',
     'ipython>=6.5,<7.5',
+    'Jinja2<3.1',
 
     # style check
     'flake8>=3.7.7,<4',


### PR DESCRIPTION
Update development dependency to pin `Jinja2`.
See release [notes](https://python.libhunt.com/jinja-changelog/3.1.0).