### PR TITLE
Fix AER model predict error after loading

### DIFF
--- a/orion/primitives/aer.py
+++ b/orion/primitives/aer.py
@@ -192,7 +192,8 @@ class AER(object):
                 N-dimensional array containing the regression for each input sequence (reverse).
         """
         X = X[:, 1:-1, :]
-        ry, y, fy = self.aer_model.predict(X)
+        x_ = self.decoder.predict(self.encoder.predict(X))
+        ry, y, fy = x_[:, 0], x_[:, 1:-1], x_[:, -1]
         return ry, y, fy
 
 


### PR DESCRIPTION
Resolve the [issue](https://github.com/sintel-dev/Orion/issues/302) with an error when calling `orion.detect` after loading an AER model.

__Cause__
In the saving process, the `__getstate__` function removes several modules, including the `aer_model`. In the loading process, the subcomponents of the model i.e. `encoder` and `decoder` are loaded but the `aer_model` was never rebuilt. Calling the `AER.predict` will result in an attribute error since `aer_model` does not exist after reloading the model.


__Changes__
- `AER.predict` function in `aer.py` to make predictions using model components instead (similar to TadGAN).