### PR TITLE
Upgrade GH actions  macos image to latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7]
-        os: [ubuntu-latest, macos-10.15, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -37,7 +37,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package
@@ -51,11 +51,11 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7]
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package and dependencies
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7]
-        os: [ubuntu-latest, macos-10.15, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -87,11 +87,11 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7]
-        os: [ubuntu-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package and dependencies
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7]
-        os: [ubuntu-latest, macos-10.15, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
* macos 10.15 will be deprecated by the end of the year. 
* upgrade to latest.