### PR TITLE
make error mask as general hyperparameter

### DIFF
--- a/docs/user_guides/primitives_pipelines/primitives/regression_errors.rst
+++ b/docs/user_guides/primitives_pipelines/primitives/regression_errors.rst
@@ -10,7 +10,7 @@ regression errors
 see `json <https://github.com/sintel-dev/Orion/blob/master/orion/primitives/jsons/orion.primitives.timeseries_errors.regression_errors.json>`__.
 
 ========================== =================== ======================================================================
-argument                    type                description  
+argument                    type                description
 
 **parameters**
 ---------------------------------------------------------------------------------------------------------------------
@@ -21,8 +21,10 @@ argument                    type                description
 **hyperparameters**
 ---------------------------------------------------------------------------------------------------------------------
 
- ``smooth``                 ``bool``            indicates whether the returned errors should be smoothed with EWMA 
- ``smoothing_window``       ``float``           size of the smoothing window, expressed as a proportion of the total 
+ ``smooth``                 ``bool``            indicates whether the returned errors should be smoothed with EWMA
+ ``smoothing_window``       ``float``           size of the smoothing window, expressed as a proportion of the total
+ ``mask``                   ``bool``            indicates whether the returned errors should be masked with the minimum error value
+ ``masking_window``         ``float``           size of the masking window, expressed as a proportion of the total
 
 **output**
 ---------------------------------------------------------------------------------------------------------------------

--- a/orion/primitives/jsons/orion.primitives.timeseries_errors.regression_errors.json
+++ b/orion/primitives/jsons/orion.primitives.timeseries_errors.regression_errors.json
@@ -40,6 +40,14 @@
                 "type": "bool",
                 "default": false
             },
+            "masking_window": {
+                "type": "float",
+                "default": 0.01,
+                "range": [
+                    0.001,
+                    0.1
+                ]
+            },
             "smoothing_window": {
                 "type": "float",
                 "default": 0.01,

--- a/orion/primitives/jsons/orion.primitives.timeseries_errors.regression_errors.json
+++ b/orion/primitives/jsons/orion.primitives.timeseries_errors.regression_errors.json
@@ -36,6 +36,10 @@
                 "type": "bool",
                 "default": true
             },
+            "mask": {
+                "type": "bool",
+                "default": false
+            },
             "smoothing_window": {
                 "type": "float",
                 "default": 0.01,

--- a/orion/primitives/timeseries_errors.py
+++ b/orion/primitives/timeseries_errors.py
@@ -10,7 +10,8 @@ from pyts.metrics import dtw
 from scipy import integrate
 
 
-def regression_errors(y, y_hat, smoothing_window=0.01, smooth=True, mask=False):
+def regression_errors(y, y_hat, smoothing_window=0.01, smooth=True,
+                      masking_window=0.01, mask=False):
     """Compute an array of absolute errors comparing predictions and expected output.
 
     If smooth is True, apply EWMA to the resulting array of errors.
@@ -43,7 +44,7 @@ def regression_errors(y, y_hat, smoothing_window=0.01, smooth=True, mask=False):
     errors = pd.Series(errors).ewm(span=smoothing_window).mean().values
 
     if mask:
-        mask_length = int(0.01 * len(errors))
+        mask_length = int(masking_window * len(errors))
         errors[:mask_length] = min(errors)
     return errors
 

--- a/orion/primitives/timeseries_errors.py
+++ b/orion/primitives/timeseries_errors.py
@@ -27,6 +27,9 @@ def regression_errors(y, y_hat, smoothing_window=0.01, smooth=True,
         smooth (bool):
             Optional. Indicates whether the returned errors should be smoothed with EWMA.
             If not given, `True` is used.
+        masking_window (float):
+            Optional. Size of the masking window, expressed as a proportion of the total
+            length of y. If not given, 0.01 is used.
         mask (bool):
             Optional. Mask the start of anomaly scores.
             If not given, `False` is used.


### PR DESCRIPTION
We observed one limitation in current prediction-based pipelines (e.g., `lstm_dynamic_threshold` and `arima`).

High anomaly scores at the early indices often result in false-positive predictions. This error is likely the byproduct
of using the exponential weighted moving average function to smooth the anomaly scores. The function requires at least
the same number of observations as the size of the smoothing window before it can produce stable anomaly scores.

In this PR, we introduced an optional masking function. Once set `True`, it will replace the beginning portion of the error scores with the minimum error value.

Resolve #352 