### PR TITLE
Pin `wrapt` for pretrained installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ pretrained_requires = [
     "timesfm[torch]>=1.2.0,<1.5;python_version>='3.11'",
     "jax;python_version>='3.11'",
 
+    'wrapt>=1.14,<1.15',
 ]
 
 


### PR DESCRIPTION
during the installation of `pretrained` package, we get the error `ImportError: cannot import name 'formatargspec' from 'inspect'` with the installation of wrapt-1.13.3.tar.gz.