### PR TITLE
Handle empty anomaly lists in the point metrics

### DIFF
--- a/orion/evaluation/point.py
+++ b/orion/evaluation/point.py
@@ -5,13 +5,13 @@ def _point_partition(expected, observed, start=None, end=None):
     expected = set(expected)
     observed = set(observed)
 
-    edge_start = min(expected.union(observed))
-    if start is not None:
-        edge_start = start
+    edge_start = start
+    if edge_start is None:
+        edge_start = min(expected.union(observed))
 
-    edge_end = max(expected.union(observed))
-    if end is not None:
-        edge_end = end
+    edge_end = end
+    if edge_end is None:
+        edge_end = max(expected.union(observed))
 
     length = int(edge_end) - int(edge_start) + 1
 
@@ -61,6 +61,13 @@ def point_confusion_matrix(expected, observed, data=None, start=None, end=None):
         expected = list(expected['timestamp'])
     if not isinstance(observed, list):
         observed = list(observed['timestamp'])
+
+    if not expected and not observed and (start is None or end is None):
+        # Without any anomalies there is no range to partition, and none was
+        # supplied through ``data``/``start``/``end``. There are no true or
+        # false positives and no false negatives, but the number of true
+        # negatives is unknown.
+        return None, 0, 0, 0
 
     return _ws(expected, observed, start, end)
 

--- a/tests/unit/evaluation/test_point.py
+++ b/tests/unit/evaluation/test_point.py
@@ -67,3 +67,36 @@ def test_point_f1_score_nan():
     observed = pd.DataFrame({"timestamp": [4, 5]})
     returned = point_f1_score(expected, observed)
     assert np.isnan(returned)
+
+
+def test_point_confusion_matrix_empty():
+    empty = pd.DataFrame({"timestamp": []})
+
+    returned = point_confusion_matrix(empty, empty)
+
+    # There is no range to partition, so the number of true negatives is
+    # unknown, but there are no positives and no false negatives.
+    assert returned == (None, 0, 0, 0)
+
+
+def test_point_confusion_matrix_empty_with_range():
+    empty = pd.DataFrame({"timestamp": []})
+
+    returned = point_confusion_matrix(empty, empty, start=0, end=9)
+
+    # Every point in the range is correctly considered normal.
+    np.testing.assert_array_equal(np.array(returned), np.array((10, 0, 0, 0)))
+
+
+def test_point_scores_empty():
+    empty = pd.DataFrame({"timestamp": []})
+
+    assert np.isnan(point_precision(empty, empty))
+    assert np.isnan(point_recall(empty, empty))
+    assert np.isnan(point_f1_score(empty, empty))
+
+    # Accuracy needs the true negatives, which are unknown without a range.
+    with pytest.raises(ValueError):
+        point_accuracy(empty, empty)
+
+    assert point_accuracy(empty, empty, start=0, end=9) == 1.0


### PR DESCRIPTION
Closes #527.

### Problem
`_point_partition` derives the partition range with `min()`/`max()` over the union of the expected and observed anomalies, *before* the `start`/`end` overrides are applied:

```python
edge_start = min(expected.union(observed))
if start is not None:
    edge_start = start
```

When neither side has any anomalies that union is empty, so every point metric raises `ValueError: min() arg is an empty sequence` — and because the `min()` runs first, supplying a range through `data`/`start`/`end` doesn't help either:

```python
>>> point_confusion_matrix([], [])
ValueError: min() arg is an empty sequence
>>> point_confusion_matrix([], [], start=0, end=9)   # a range is known, still raises
ValueError: min() arg is an empty sequence
```

### Fix
Take `start`/`end` into account first and only fall back to `min()`/`max()` when they aren't given, so a known range is enough to build the partition. If there are no anomalies *and* no range to fall back on, return an empty confusion matrix as you specified on the issue — there are no true or false positives and no false negatives, but the number of true negatives is unknown. That is the same `(None, fp, fn, tp)` shape `contextual.py` already returns when the true negatives can't be determined, so it keeps the 4-tuple contract the metrics unpack.

### Resulting behaviour

| call | before | after |
|---|---|---|
| `point_confusion_matrix([], [])` | `ValueError` | `(None, 0, 0, 0)` |
| `point_confusion_matrix([], [], start=0, end=9)` | `ValueError` | `[10, 0, 0, 0]` (all true negatives) |
| `point_precision/recall/f1_score([], [])` | `ValueError` | `nan`, via the existing zero-division handling |
| `point_accuracy([], [])` | `ValueError: min() arg…` | the existing "cannot obtain accuracy" error, since the true negatives are unknown |
| `point_accuracy([], [], start=0, end=9)` | `ValueError` | `1.0` |

Everything with at least one anomaly on either side is untouched — `point_confusion_matrix([1,2,3], [2,3,4])` still returns `[0, 1, 1, 2]`, and `[2, 1, 1, 2]` with `start=0, end=5`.

### Tests
Added `test_point_confusion_matrix_empty`, `test_point_confusion_matrix_empty_with_range` and `test_point_scores_empty`; all three fail on `master` and pass here. `tests/unit/evaluation` passes (36 tests), and `flake8`/`isort` are clean on the changed files.
